### PR TITLE
Resolve warnings

### DIFF
--- a/include/fvad.h
+++ b/include/fvad.h
@@ -33,7 +33,7 @@ typedef struct Fvad Fvad;
  *
  * Returns NULL in case of a memory allocation error.
  */
-Fvad *fvad_new();
+Fvad *fvad_new(void);
 
 /*
  * Frees the dynamic memory of a specified VAD instance.

--- a/src/fvad.c
+++ b/src/fvad.c
@@ -31,11 +31,11 @@ static const size_t valid_frame_times[] = { 10, 20, 30 };
 
 struct Fvad {
     VadInstT core;
-    int rate_idx; // index in valid_rates and process_funcs arrays
+    size_t rate_idx; // index in valid_rates and process_funcs arrays
 };
 
 
-Fvad *fvad_new()
+Fvad *fvad_new(void)
 {
     Fvad *inst = malloc(sizeof *inst);
     if (inst) fvad_reset(inst);
@@ -82,7 +82,7 @@ int fvad_set_sample_rate(Fvad* inst, int sample_rate)
 }
 
 
-static bool valid_length(int rate_idx, size_t length)
+static bool valid_length(size_t rate_idx, size_t length)
 {
     int samples_per_ms = valid_rates[rate_idx];
     for (size_t i = 0; i < arraysize(valid_frame_times); i++) {


### PR DESCRIPTION
- Use `void` to specify that `fvad_new` takes no arguments
- Change `rate_idx` to be type `size_t` so that line 77 of fvad.c does not attempt casting `size_t` to `int`