### PR TITLE
Add build of example with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(libfvad VERSION 1.0.1 LANGUAGES C)
 
+option(ENABLE_EXAMPLES "build the fvadwav example program; requires libsndfile" OFF)
+
 include_directories(include)
 add_subdirectory(src)
-install(DIRECTORY include DESTINATION .)
+if(${ENABLE_EXAMPLES})
+    add_subdirectory(examples)
+endif()
 
+install(DIRECTORY include DESTINATION .)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.5)
+
+add_executable(fvadwav fvadwav.c)
+target_link_libraries(fvadwav sndfile fvad)
+install(TARGETS fvadwav DESTINATION bin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ set(SOURCES common.h
             vad/vad_gmm.c
             vad/vad_sp.h
             vad/vad_sp.c)
-            
+
 add_library(fvad STATIC ${SOURCES})
 set_property(TARGET fvad PROPERTY POSITION_INDEPENDENT_CODE 1)
 install(TARGETS fvad DESTINATION lib)


### PR DESCRIPTION
Added ability to build example with CMake. Building of examples is switched on\off with ENABLE_EXAMPLES option.