### PR TITLE
fvad_new: Fix compile error

### DIFF
--- a/src/fvad.c
+++ b/src/fvad.c
@@ -37,7 +37,7 @@ struct Fvad {
 
 Fvad *fvad_new(void)
 {
-    Fvad *inst = malloc(sizeof *inst);
+    Fvad *inst = (Fvad *)malloc(sizeof *inst);
     if (inst) fvad_reset(inst);
     return inst;
 }


### PR DESCRIPTION
Need to cast explicitly, otherwise can get a compile warning/error on some compilers.