### PR TITLE
Added target_include_directories command in the src/CMakeLists to include header directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,5 +21,11 @@ set(SOURCES common.h
             vad/vad_sp.c)
 
 add_library(fvad STATIC ${SOURCES})
+
+target_include_directories(fvad
+    PUBLIC
+        ../include
+)
+
 set_property(TARGET fvad PROPERTY POSITION_INDEPENDENT_CODE 1)
 install(TARGETS fvad DESTINATION lib)


### PR DESCRIPTION
I'm using `libfvad` with `SDL`, and to have it working properly I had to add the following `include_directories` command in my project's `CMakeLists` file:
```
include_directories(
  "${PROJECT_SOURCE_DIR}/build/_deps/fvad-src/include"
)
```
To avoid having to add the `include_directories` in my own `CMakeLists`, the best solution I found was adding the `target_include_directories` command in the `CMakeLists` that is located inside the `libfvad/src`, as you can see in this pull request. 
It also works if I add it in the `CMakeLists` file in the root of the repository, however, it makes more sense to me to keep this command where the `fvad` library is created.  
I can confirm it works on my project, and in the libfvad fork I made as well. Let me know if any extra test or steps are required.
Thank you! 