### PR TITLE
vad_core: Expose filterbank/power features

### DIFF
--- a/src/vad/vad_core.c
+++ b/src/vad/vad_core.c
@@ -670,14 +670,13 @@ int WebRtcVad_CalcVad16khz(VadInstT* inst, const int16_t* speech_frame,
 int WebRtcVad_CalcVad8khz(VadInstT* inst, const int16_t* speech_frame,
                           size_t frame_length)
 {
-    int16_t feature_vector[kNumChannels], total_power;
 
     // Get power in the bands
-    total_power = WebRtcVad_CalculateFeatures(inst, speech_frame, frame_length,
-                                              feature_vector);
+    inst->total_power = WebRtcVad_CalculateFeatures(inst, speech_frame, frame_length,
+                                              inst->feature_vector);
 
     // Make a VAD
-    inst->vad = GmmProbability(inst, feature_vector, total_power, frame_length);
+    inst->vad = GmmProbability(inst, inst->feature_vector, inst->total_power, frame_length);
 
     return inst->vad;
 }

--- a/src/vad/vad_core.h
+++ b/src/vad/vad_core.h
@@ -48,6 +48,9 @@ typedef struct VadInstT_ {
     int16_t individual[3];
     int16_t total[3];
 
+    int16_t feature_vector[kNumChannels];
+    int16_t total_power;
+
     int init_flag;
 } VadInstT;
 


### PR DESCRIPTION
This enables code using libfvad to access the features from the outside. Very useful to do additional VAD processing, for visualization, or to use the code for other audio/speech feature extraction - as it is one of the fastest and most portable filterbank implementations available.