### PR TITLE
Fix C11 compiler support check in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_INIT([libfvad],[1.0],[dpirch@gmail.com],[],[https://github.com/dpirch/libfvad])
-AC_PREREQ([2.60]) # for _AC_C_STD_TRY
+AC_PREREQ([2.60])
 AC_CONFIG_SRCDIR([src/fvad.c])
 AC_CONFIG_AUX_DIR([ac-aux])
 AC_CONFIG_MACRO_DIR([m4])
@@ -10,17 +10,12 @@ AM_INIT_AUTOMAKE([
 
 AC_PROG_CC
 
-# Try to make the compiler support C11 (and C99). Necessary for older versions
-# of gcc and clang (e.g. gcc 4.8) that default to C89.
-# Temporary solution until autoconf 2.70, when we can use AC_PROG_CC for this.
-_AC_C_STD_TRY(
-    [c11],
-    [#include <assert.h>],
-    [static_assert(1, "foo"); for (int i = 0; i < 1; i++) ],
-    [-std=gnu11 -std=c11],
-    [],
-    [AC_MSG_ERROR([compiler does not support C11])]
-)
+# Manually check for C11 support by setting the required flag and testing a simple feature.
+CFLAGS="$CFLAGS -std=c11"
+AC_MSG_CHECKING([for C11 support])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[_Static_assert(1, "1 is true");]])],
+                  [AC_MSG_RESULT([yes])],
+                  [AC_MSG_ERROR([Your compiler does not support C11, which is required.])])
 
 LT_INIT([disable-static pic-only])
 


### PR DESCRIPTION
Replaced the undefined _AC_C_STD_TRY macro with a manual compiler support check for C11 using standard Autoconf macros. This ensures compatibility with Autoconf 2.71 and resolves configuration errors related to compiler feature checks. The update includes a direct setting of C11 flags and a compile test to verify support, improving the build configuration's robustness and portability.